### PR TITLE
chore: clean up devcontainer.json by removing unused properties

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,15 +3,13 @@
 {
 	"name": "Node.js",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:24",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:24"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	"features": {
-		"ghcr.io/devcontainers/features/common-utils:2": {}
-	},
+	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [8000]
+	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "yarn install",


### PR DESCRIPTION
This pull request makes a minor update to the `.devcontainer/devcontainer.json` configuration by removing the `common-utils` feature and commenting out the `forwardPorts` setting. No major functionality is changed, but the dev container setup is now more minimal.

- Dev container configuration:
  * Removed the `common-utils` feature from the `features` section in `.devcontainer/devcontainer.json`.
  * Commented out the `forwardPorts` setting, so no ports are explicitly forwarded by default.