### PR TITLE
chore: clean up configuration files and add mise.toml for tool settings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,22 +1,4 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
 {
 	"name": "Node.js",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/javascript-node:24"
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "yarn install",
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,17 @@
 node_modules
 .DS_Store
+
+# mise
+# https://mise.jdx.dev/configuration.html
+# https://mise.jdx.dev/configuration/environments.html
+.mise.*.local.toml
+.mise.local.toml
+mise.*.local.toml
+mise.local.toml
+.mise/*.local.toml
+mise/*.local.toml
+
+# Agents
+.claude/
+.codex/
+.gemini/

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "24"
+pnpm = "10"

--- a/package.json
+++ b/package.json
@@ -5,15 +5,18 @@
   "dependencies": {
     "zenn-cli": "^0.4.4"
   },
+  "engines": {
+    "node": "^24"
+  },
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": ">=24 <25"
+      "version": "^24"
     },
     "packageManager": [
       {
         "name": "pnpm",
-        "version": ">=10 <11"
+        "version": "^10"
       }
     ]
   }


### PR DESCRIPTION
This pull request updates the development environment configuration to standardize on Node.js version 24 and pnpm version 10. The changes ensure consistency across tooling and container setup.

Tooling and runtime version standardization:

* Added a `mise.toml` file specifying Node.js version 24 and pnpm version 10 for local development tooling.
* Updated the `package.json` engine and devEngine constraints to require Node.js 24 and pnpm 10, replacing previous range-based constraints with caret ranges for clarity and consistency.

Dev container cleanup:

* Simplified `.devcontainer/devcontainer.json` by removing commented configuration options and retaining only the base image specification, reducing clutter and focusing on essential settings.