### PR TITLE
chore: add GitHub CLI feature to devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,7 @@
 {
 	"name": "Node.js",
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:24"
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:24",
+	"features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
-	"name": "Node.js",
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:24",
-	"features": {
+  "name": "Node.js",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:24",
+  "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {}
   }
 }


### PR DESCRIPTION
This pull request updates the development container configuration to include the GitHub CLI tool by default. This will make it easier for developers to interact with GitHub from within the dev container.

Development environment improvement:

* Added the GitHub CLI feature to the dev container by updating the `features` section in `.devcontainer/devcontainer.json`.