### PR TITLE
chore: downgrade Node.js version from 24 to 22 in configuration files

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Node.js",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:24",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {}
   }

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-node = "24"
+node = "22"
 pnpm = "10"

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
     "zenn-cli": "^0.4.4"
   },
   "engines": {
-    "node": "^24"
+    "node": "^22"
   },
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": "^24"
+      "version": "^22"
     },
     "packageManager": [
       {


### PR DESCRIPTION
This pull request downgrades the Node.js version used across the development environment and project configuration from version 24 to version 22. This ensures consistency in local development, dependency management, and runtime requirements.

Development environment and configuration updates:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L3-R3): Changed the dev container image to use Node.js version 22 instead of 24.
* [`mise.toml`](diffhunk://#diff-3c9056799ce8e353b18de841a8b9c8492d46cb096e063c86fb0ce54cfcd117c2L2-R2): Updated the Node.js version requirement to 22 for tool management.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L9-R14): Modified both the `engines.node` and `devEngines.runtime.version` fields to require Node.js version 22 instead of 24.